### PR TITLE
Fixes #17

### DIFF
--- a/android/src/main/kotlin/com/jfacoustic/flutter_auth0_client/FlutterAuth0ClientPlugin.kt
+++ b/android/src/main/kotlin/com/jfacoustic/flutter_auth0_client/FlutterAuth0ClientPlugin.kt
@@ -73,7 +73,7 @@ class FlutterAuth0ClientPlugin() : FlutterPlugin, MethodCallHandler, ActivityAwa
       loginMethod.start(this.activity!!, object : Callback<Credentials, AuthenticationException> {
         // Called when there is an authentication failure
         override fun onFailure(exception: AuthenticationException) {
-          result.error("AuthenticationException", exception.message, activity)
+          result.error("AuthenticationException", exception.message, null)
         }
 
         // Called when authentication completed successfully
@@ -94,7 +94,7 @@ class FlutterAuth0ClientPlugin() : FlutterPlugin, MethodCallHandler, ActivityAwa
         }
       })
     } catch (e: Exception) {
-      result.error("AuthenticationException", e.message, activity)
+      result.error("AuthenticationException", e.message, null)
     }
   }
 


### PR DESCRIPTION
MethodChannel.Result.error accepts a nullable Object containing error details as its 3rd parameter and not an Activity.